### PR TITLE
Importable by create react app

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "clean": "rm -rf ./dist",
     "size": "./node_modules/.bin/size-limit",
     "analyze": "./node_modules/.bin/size-limit --why",
-    "pub": "yarn build && yalc publish"
+    "pub": "yarn build && yalc publish --push",
+    "dev": "nodemon -i dist -x \"yarn pub\""
   },
   "module": "./dist/key-did-provider-secp256k1.esm.js",
   "devDependencies": {
@@ -57,7 +58,7 @@
     "elliptic": "^6.5.4",
     "fast-json-stable-stringify": "^2.1.0",
     "global": "^4.4.0",
-    "lit-js-sdk": "https://github.com/LIT-Protocol/lit-js-sdk.git#serrano",
+    "lit-js-sdk": "^1.2.0",
     "rpc-utils": "^0.6.2",
     "uint8arrays": "^3.0.0",
     "watch": "^1.0.2"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "typings": "./dist/index.d.ts",
   "sideEffects": false,
   "files": [
-    "dist/*"
+    "dist/*",
+    ".yalc"
   ],
   "engines": {
     "node": ">=14.14"
@@ -58,7 +59,7 @@
     "elliptic": "^6.5.4",
     "fast-json-stable-stringify": "^2.1.0",
     "global": "^4.4.0",
-    "lit-js-sdk": "^1.2.0",
+    "lit-js-sdk": "^1.2.1",
     "rpc-utils": "^0.6.2",
     "uint8arrays": "^3.0.0",
     "watch": "^1.0.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,14 +218,15 @@ export function ES256KSignerWithLit(): Signer {
   return async (data: string | Uint8Array): Promise<string> => {
     log("ES256KSignerWithLit:", sha256(data));
 
-    const singature = (await litActionSignAndGetSignature(sha256(data))).sig1;
+    const signature = (await litActionSignAndGetSignature(sha256(data))).sig1;
+    // log("ES256KSignerWithLit signature:", signature);
 
     // const { r, s, recoveryParam }: elliptic.ec.Signature = keyPair.sign(sha256(data))
     return toJose(
       {
-        r: singature.r,
-        s: singature.s,
-        recoveryParam: singature.recid,
+        r: signature.r,
+        s: signature.s,
+        recoveryParam: signature.recid,
       },
       recoverable
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
-import { 
-  ES256KSigner,
-  Signer,
-  createJWS
-} from 'did-jwt'
+import { ES256KSigner, Signer, createJWS } from "did-jwt";
 
 import type {
   AuthParams,
@@ -12,52 +8,42 @@ import type {
   DIDProvider,
   GeneralJWS,
   DecryptJWEParams,
-} from 'dids'
+} from "dids";
 
-import { 
-  toGeneralJWS, 
-  toJose, 
-  toStableObject,
-  sha256,
-  log
-} from './util'
+import { toGeneralJWS, toJose, toStableObject, sha256, log } from "./util.js";
 
-import type { 
-  HandlerMethods, 
-  RPCRequest, 
-  RPCResponse, 
-  SendRequestFunc, 
-  RPCConnection 
-} from 'rpc-utils'
+import type {
+  HandlerMethods,
+  RPCRequest,
+  RPCResponse,
+  SendRequestFunc,
+  RPCConnection,
+} from "rpc-utils";
 
-import {
-  RPCError, 
-  createHandler 
-} from 'rpc-utils'
+import { RPCError, createHandler } from "rpc-utils";
 
-import * as u8a from 'uint8arrays'
-import elliptic from 'elliptic'
+import * as u8a from "uint8arrays";
+import elliptic from "elliptic";
 
-const LitJsSdk = require('lit-js-sdk')
+import LitJsSdk from "lit-js-sdk";
 log("LitJsSdk:", LitJsSdk, true);
 
 const EC = elliptic.ec;
-const ec = new EC('secp256k1')
+const ec = new EC("secp256k1");
 
 interface Context {
-  did: string
-  secretKey: Uint8Array
+  did: string;
+  secretKey: Uint8Array;
 }
 
 export function encodeDID(publicKey: Uint8Array): string {
-
-  const bytes = new Uint8Array(publicKey.length + 2)
-  bytes[0] = 0xe7 // secp256k1 multicodec
+  const bytes = new Uint8Array(publicKey.length + 2);
+  bytes[0] = 0xe7; // secp256k1 multicodec
   // The multicodec is encoded as a varint so we need to add this.
   // See js-multicodec for a general implementation
-  bytes[1] = 0x01
-  bytes.set(publicKey, 2)
-  return `did:key:z${u8a.toString(bytes, 'base58btc')}`
+  bytes[1] = 0x01;
+  bytes.set(publicKey, 2);
+  return `did:key:z${u8a.toString(bytes, "base58btc")}`;
 }
 
 const sign = async (
@@ -66,17 +52,21 @@ const sign = async (
   secretKey: Uint8Array,
   protectedHeader: Record<string, any> = {}
 ) => {
-
-  const kid = `${did}#${did.split(':')[2]}`
-  const signer = ES256KSigner(secretKey)
+  const kid = `${did}#${did.split(":")[2]}`;
+  const signer = ES256KSigner(secretKey);
 
   log("signer:", signer);
 
-  const header = toStableObject(Object.assign(protectedHeader, { kid, alg: 'ES256K' }))
+  const header = toStableObject(
+    Object.assign(protectedHeader, { kid, alg: "ES256K" })
+  );
 
-  return createJWS(typeof payload === 'string' ? payload : toStableObject(payload), signer, header)
-}
-
+  return createJWS(
+    typeof payload === "string" ? payload : toStableObject(payload),
+    signer,
+    header
+  );
+};
 
 const didMethods: HandlerMethods<Context, DIDProviderMethods> = {
   did_authenticate: async ({ did, secretKey }, params: AuthParams) => {
@@ -90,43 +80,46 @@ const didMethods: HandlerMethods<Context, DIDProviderMethods> = {
       },
       did,
       secretKey
-    )
-    return toGeneralJWS(response)
+    );
+    return toGeneralJWS(response);
   },
-  did_createJWS: async ({ did, secretKey }, params: CreateJWSParams & { did: string }) => {
-    const requestDid = params.did.split('#')[0]
-    if (requestDid !== did) throw new RPCError(4100, `Unknown DID: ${did}`)
-    const jws = await sign(params.payload, did, secretKey, params.protected)
-    return { jws: toGeneralJWS(jws) }
+  did_createJWS: async (
+    { did, secretKey },
+    params: CreateJWSParams & { did: string }
+  ) => {
+    const requestDid = params.did.split("#")[0];
+    if (requestDid !== did) throw new RPCError(4100, `Unknown DID: ${did}`);
+    const jws = await sign(params.payload, did, secretKey, params.protected);
+    return { jws: toGeneralJWS(jws) };
   },
   did_decryptJWE: async () => {
     // Not implemented
-    return { cleartext: '' }
+    return { cleartext: "" };
   },
-}
+};
 
 export class Secp256k1Provider implements DIDProvider {
-  _handle: SendRequestFunc<DIDProviderMethods>
+  _handle: SendRequestFunc<DIDProviderMethods>;
 
   constructor(seed: Uint8Array) {
-    const publicKey = ec.keyFromPrivate(seed).getPublic(true, 'array')    
-    const did = encodeDID(Uint8Array.from(publicKey))
+    const publicKey = ec.keyFromPrivate(seed).getPublic(true, "array");
+    const did = encodeDID(Uint8Array.from(publicKey));
 
-    const handler = createHandler<Context, DIDProviderMethods>(didMethods)
-    this._handle = async (msg) => {      
-      const _handler = await handler({ did, secretKey:seed }, msg);
+    const handler = createHandler<Context, DIDProviderMethods>(didMethods);
+    this._handle = async (msg) => {
+      const _handler = await handler({ did, secretKey: seed }, msg);
       return _handler;
-    }
+    };
   }
 
   get isDidProvider(): boolean {
-    return true
+    return true;
   }
 
   async send<Name extends DIDMethodName>(
     msg: RPCRequest<DIDProviderMethods, Name>
   ): Promise<RPCResponse<DIDProviderMethods, Name> | null> {
-    return await this._handle(msg)
+    return await this._handle(msg);
   }
 }
 
@@ -135,15 +128,14 @@ export class Secp256k1Provider implements DIDProvider {
 // --------------------------------------------------
 
 interface ContextWithLit {
-  did: string
+  did: string;
 }
 
 const getPKPPublicKey = async () => {
-
   const authSig = await LitJsSdk.checkAndSignAuthMessage({ chain: "ethereum" });
 
   const litNodeClient = new LitJsSdk.LitNodeClient({ litNetwork: "serrano" });
-  
+
   await litNodeClient.connect();
 
   const signatures = await litNodeClient.executeJs({
@@ -158,19 +150,17 @@ const getPKPPublicKey = async () => {
   });
 
   return signatures.sig1.publicKey;
-
-}
+};
 
 const litActionSignAndGetSignature = async (dataToSign: Uint8Array) => {
-
-  log("litActionSignAndGetSignature:", dataToSign)
+  log("litActionSignAndGetSignature:", dataToSign);
 
   //  -- validate
-  if(dataToSign == undefined ) throw Error('dataToSign cannot be empty')
+  if (dataToSign == undefined) throw Error("dataToSign cannot be empty");
 
   // -- prepare
   const DATA_TO_SIGN_IN_STRING = Array.from(dataToSign).toString();
-  
+
   const litCode = `
     const go = async () => {
 
@@ -196,42 +186,40 @@ const litActionSignAndGetSignature = async (dataToSign: Uint8Array) => {
   });
 
   return signatures;
-}
+};
 
 export async function encodeDIDWithLit(): Promise<string> {
-
   const PKP_PUBLIC_KEY = await getPKPPublicKey();
 
   log("[encodeDIDWithLit] PKP_PUBLIC_KEY:", PKP_PUBLIC_KEY);
 
-  const pubBytes = ec.keyFromPublic(PKP_PUBLIC_KEY, 'hex').getPublic(true, 'array');
+  const pubBytes = ec
+    .keyFromPublic(PKP_PUBLIC_KEY, "hex")
+    .getPublic(true, "array");
 
-  log("[encodeDIDWithLit] pubBytes:", pubBytes)
+  log("[encodeDIDWithLit] pubBytes:", pubBytes);
 
   // https://github.com/multiformats/multicodec/blob/master/table.csv
   const bytes = new Uint8Array(pubBytes.length + 2);
-  bytes[0] = 0xe7 // <-- 0xe7 is a Secp256k1 public key (compressed)
-  bytes[1] = 0x01 // <-- 0x01 is a content identifier cidv1
-  bytes.set(pubBytes, 2)
-  log("[encodeDIDWithLit] bytes:", bytes)
+  bytes[0] = 0xe7; // <-- 0xe7 is a Secp256k1 public key (compressed)
+  bytes[1] = 0x01; // <-- 0x01 is a content identifier cidv1
+  bytes.set(pubBytes, 2);
+  log("[encodeDIDWithLit] bytes:", bytes);
 
-  const did = `did:key:z${u8a.toString(bytes, 'base58btc')}`;
-  log(`[encodeDIDWithLit] did:`, did)
+  const did = `did:key:z${u8a.toString(bytes, "base58btc")}`;
+  log(`[encodeDIDWithLit] did:`, did);
 
   return did;
-
 }
 
 export function ES256KSignerWithLit(): Signer {
-
   const recoverable = false;
 
   return async (data: string | Uint8Array): Promise<string> => {
-
-    log("ES256KSignerWithLit:", sha256(data))
+    log("ES256KSignerWithLit:", sha256(data));
 
     const singature = (await litActionSignAndGetSignature(sha256(data))).sig1;
-    
+
     // const { r, s, recoveryParam }: elliptic.ec.Signature = keyPair.sign(sha256(data))
     return toJose(
       {
@@ -240,56 +228,63 @@ export function ES256KSignerWithLit(): Signer {
         recoveryParam: singature.recid,
       },
       recoverable
-    )
-  }
+    );
+  };
 }
 
 export declare type DIDProviderMethodsWithLit = {
   did_authenticate: {
-      params: AuthParams;
-      result: GeneralJWS;
+    params: AuthParams;
+    result: GeneralJWS;
   };
   did_createJWS: {
-      params: CreateJWSParams;
-      result: {
-          jws: GeneralJWS;
-      };
+    params: CreateJWSParams;
+    result: {
+      jws: GeneralJWS;
+    };
   };
   did_decryptJWE: {
-      params: DecryptJWEParams;
-      result: {
-          cleartext: string;
-      };
+    params: DecryptJWEParams;
+    result: {
+      cleartext: string;
+    };
   };
 };
-
 
 const signWithLit = async (
   payload: Record<string, any> | string,
   did: string,
   protectedHeader: Record<string, any> = {}
 ) => {
-
   log("[signWithLit] did:", did);
 
-  const kid = `${did}#${did.split(':')[2]}`
+  const kid = `${did}#${did.split(":")[2]}`;
 
   log("[signWithLit] kid:", kid);
-  
+
   const signer = ES256KSignerWithLit();
 
   log("[signWithLit] signer:", signer);
-  
-  const header = toStableObject(Object.assign(protectedHeader, { kid, alg: 'ES256K' }))
 
-  log("[signWithLit] header:", header)
+  const header = toStableObject(
+    Object.assign(protectedHeader, { kid, alg: "ES256K" })
+  );
 
-  log("[signWithLit] payload:", payload)
+  log("[signWithLit] header:", header);
 
-  return createJWS(typeof payload === 'string' ? payload : toStableObject(payload), signer, header);
-}
+  log("[signWithLit] payload:", payload);
 
-const didMethodsWithLit: HandlerMethods<ContextWithLit, DIDProviderMethodsWithLit> = {
+  return createJWS(
+    typeof payload === "string" ? payload : toStableObject(payload),
+    signer,
+    header
+  );
+};
+
+const didMethodsWithLit: HandlerMethods<
+  ContextWithLit,
+  DIDProviderMethodsWithLit
+> = {
   did_authenticate: async ({ did }, params: AuthParams) => {
     const response = await signWithLit(
       {
@@ -300,10 +295,10 @@ const didMethodsWithLit: HandlerMethods<ContextWithLit, DIDProviderMethodsWithLi
         exp: Math.floor(Date.now() / 1000) + 600, // expires 10 min from now
       },
       did
-    )
+    );
 
     log("[didMethodsWithLit] response:", response);
-    
+
     const general = toGeneralJWS(response);
 
     log("[didMethodsWithLit] general:", general);
@@ -311,47 +306,49 @@ const didMethodsWithLit: HandlerMethods<ContextWithLit, DIDProviderMethodsWithLi
     return general;
   },
   did_createJWS: async ({ did }, params: CreateJWSParams & { did: string }) => {
-    const requestDid = params.did.split('#')[0]
-    if (requestDid !== did) throw new RPCError(4100, `Unknown DID: ${did}`)
-    const jws = await signWithLit(params.payload, did, params.protected)
+    const requestDid = params.did.split("#")[0];
+    if (requestDid !== did) throw new RPCError(4100, `Unknown DID: ${did}`);
+    const jws = await signWithLit(params.payload, did, params.protected);
 
-    log("[did_createJWS] jws:", jws)
+    log("[did_createJWS] jws:", jws);
 
-    return { jws: toGeneralJWS(jws) }
+    return { jws: toGeneralJWS(jws) };
   },
   did_decryptJWE: async () => {
     // Not implemented
-    return { cleartext: '' }
+    return { cleartext: "" };
   },
-}
+};
 
 export declare type DIDMethodNameWithLit = keyof DIDProviderMethodsWithLit;
 
-export declare type DIDProviderWithLit = RPCConnection<DIDProviderMethodsWithLit>;
+export declare type DIDProviderWithLit =
+  RPCConnection<DIDProviderMethodsWithLit>;
 
-// 
+//
 // Lit version of Secp256k1Provider without private key
-// 
+//
 export class Secp256k1ProviderWithLit implements DIDProviderWithLit {
-  _handle: SendRequestFunc<DIDProviderMethodsWithLit>
+  _handle: SendRequestFunc<DIDProviderMethodsWithLit>;
 
   constructor(did: string) {
-    
-    const handler = createHandler<ContextWithLit, DIDProviderMethodsWithLit>(didMethodsWithLit)
+    const handler = createHandler<ContextWithLit, DIDProviderMethodsWithLit>(
+      didMethodsWithLit
+    );
     this._handle = async (msg) => {
-      log('[Secp256k1ProviderWithLit] this._handle(msg):', msg);
-      const _handler = await handler({ did }, msg); 
+      log("[Secp256k1ProviderWithLit] this._handle(msg):", msg);
+      const _handler = await handler({ did }, msg);
       return _handler;
-    }
+    };
   }
 
   get isDidProvider(): boolean {
-    return true
+    return true;
   }
 
   async send<Name extends DIDMethodNameWithLit>(
     msg: RPCRequest<DIDProviderMethodsWithLit, Name>
   ): Promise<RPCResponse<DIDProviderMethodsWithLit, Name> | null> {
-    return await this._handle(msg)
+    return await this._handle(msg);
   }
 }

--- a/yalc.lock
+++ b/yalc.lock
@@ -1,9 +1,0 @@
-{
-  "version": "v1",
-  "packages": {
-    "lit-js-sdk": {
-      "signature": "f33c54121a9ee2986f4cb7da7484ae3f",
-      "file": true
-    }
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,9 +3927,10 @@ lit-connect-modal@^0.1.8:
   dependencies:
     micromodal "^0.4.10"
 
-"lit-js-sdk@https://github.com/LIT-Protocol/lit-js-sdk.git#serrano":
+lit-js-sdk@^1.2.0:
   version "1.2.0"
-  resolved "https://github.com/LIT-Protocol/lit-js-sdk.git#a2d963af419211f2de8c28406e5ae9fea8f45c89"
+  resolved "https://registry.yarnpkg.com/lit-js-sdk/-/lit-js-sdk-1.2.0.tgz#03f2eb57759d84d8c56c2e9f247a1a6d61924dd6"
+  integrity sha512-jjChqfVbffDrFwSWNplGxoSSoUjaEJTrJFkDW2IJHRFiAzAxnEf6UKhEs0IFZ9hQ+dU/7jKQoe8bWY1+rHBsLg==
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/contracts" "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,10 +3927,10 @@ lit-connect-modal@^0.1.8:
   dependencies:
     micromodal "^0.4.10"
 
-lit-js-sdk@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/lit-js-sdk/-/lit-js-sdk-1.2.0.tgz#03f2eb57759d84d8c56c2e9f247a1a6d61924dd6"
-  integrity sha512-jjChqfVbffDrFwSWNplGxoSSoUjaEJTrJFkDW2IJHRFiAzAxnEf6UKhEs0IFZ9hQ+dU/7jKQoe8bWY1+rHBsLg==
+lit-js-sdk@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/lit-js-sdk/-/lit-js-sdk-1.2.1.tgz#23cd905ef5f3723327854a2eaa625a3b6abab684"
+  integrity sha512-MxyzBvWSiMe1+GuPuQY3InMhsl2YAfIlMSib7aLz5+5X9PO8uC7Myi6zd7TJb6oxnJ/HyKkPju/OwBva1XfhIw==
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/contracts" "^5.2.0"


### PR DESCRIPTION
Apologies for the massive changes - I have prettier with format on save turned on in VS Code and it reformatted all the code.

The main changes I made are:

* import util.js instead of just util.  when imported, create-react-app was complaining about that
* added typescript module thingy to fix a module not found error
* use lit-js-sdk@serrano version of the lit-js-sdk because it has everything needed
* added .yalc to files array in package.json.  we might need to remove this when we publish the package. the reason i had to add this is because in my create-react-app project, i did `yalc add key-did-provider-secp256k1-with-lit`.  and in this project, i did `yalc add lit-js-sdk`.  Well, when I published this project with yalc, it would copy this project into the .yalc directory of the create-react-app project, but it only brings the files in the files array in package.json.  so it wouldn't copy over the .yalc folder that contained the new version of lit-js-sdk and the create-react-app project was complaining that .yalc/key-did-provider-secp256k1-with-lit/.yalc/lit-js-sdk didn't exist.  I'm mainly explaining this in so much detail so that you know about this when you're using yalc with a dependency of a dependency.